### PR TITLE
updated maven dependency for UserAgentUtils

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -21,7 +21,7 @@ grails.project.dependency.resolution = {
         mavenRepo 'https://raw.githubusercontent.com/HaraldWalker/user-agent-utils/mvn-repo/'
     }
     dependencies {
-        compile 'bitwalker:UserAgentUtils:1.14'
+        compile 'eu.bitwalker:UserAgentUtils:1.14'
     }
 
     plugins {


### PR DESCRIPTION
The maven group id of UserAgentUtils has changed. Please see here: https://github.com/HaraldWalker/user-agent-utils/commit/6cf1c761d803610e55e3f7bdd6bfb818ffa31c14.
Without this change the plugin won't install.
